### PR TITLE
docs(*): update markdown files and fix typos - I257

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to Concerto-UI
 
-> Thanks to the angularJS team for the bulk of this text!
+> Thanks to the AngularJS team for the bulk of this text!
 
 We'd love for you to contribute to our source code and to make Concerto-UI even better than it is today! Here are the guidelines we'd like you to follow:
 
@@ -37,13 +37,13 @@ Other channels for support are:
 
 ### <a name="issue"></a> Found an Issue or Bug?
 
-If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github-issues]. Even better, you can submit a Pull Request with a fix.
+If you find a bug in the source code, you can help us by submitting an issue to our [GitHub Repository][github]. Even better, you can submit a Pull Request with a fix.
 
 **Please see the **[**Submission Guidelines**][contribute.submit]** below.**
 
 ### <a name="feature"></a> Missing a Feature?
 
-You can request a new feature by submitting an issue to our [GitHub Repository][github-issues].
+You can request a new feature by [submitting an issue][github-issues] to our GitHub Repository.
 
 If you would like to implement a new feature then consider what kind of change it is:
 
@@ -55,7 +55,7 @@ If you would like to implement a new feature then consider what kind of change i
 
   as a Pull Request. See the section about [Pull Request Submission Guidelines][contribute.submitpr], and
 
-  for detailed information the [core development documentation][developers].
+  for detailed information read the [core development documentation][developers].
 
 ### <a name="docs"></a> Want a Doc Fix?
 
@@ -82,7 +82,7 @@ The "[new issue][github-new-issue]" form contains a number of prompts that you s
 Before you submit your pull request consider the following guidelines:
 
 * Ensure there is an open [Issue][github-issues] for what you will be working on. If there is not, open one up by going through [these guidelines][contribute.submit].
-* Search [GitHub][pulls] for an open or closed Pull Request that relates to your submission. You don't want to duplicate effort.
+* Search for an open or closed [Pull Request][pulls] that relates to your submission. You don't want to duplicate effort.
 * Create the [development environment][developers.setup]
 * Make your changes in a new git branch:
 
@@ -100,7 +100,7 @@ Before you submit your pull request consider the following guidelines:
 * Follow our [Coding Rules][developers.rules].
 * Ensure you provide a DCO sign-off for your commits using the -s option of git commit. For more information see [how this works][dcohow].
 * If the changes affect public APIs, change or add relevant [documentation][developers.documentation].
-* Run the [unit][developers.unit-tests] test suite, and ensure that all tests pass.
+* Run the [unit test suite][developers.unit-tests], and ensure that all tests pass.
 
 * Commit your changes using a descriptive commit message that follows our [commit message conventions][developers.commits]. Adherence to the [commit message conventions][developers.commits] is required, because release notes are automatically generated from these messages.
 
@@ -110,7 +110,7 @@ Before you submit your pull request consider the following guidelines:
 
   Note: the optional commit `-a` command line option will automatically "add" and "rm" edited files.
 
-* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-fowarding master:
+* Before creating the Pull Request, ensure your branch sits on top of master (as opposed to branch off a branch). This ensures the reviewer will need only minimal effort to integrate your work by fast-forwarding master:
 
   ```text
     git rebase upstream/master
@@ -143,7 +143,7 @@ Before you submit your pull request consider the following guidelines:
     git push origin name-issue-tracker-short-description -f
     ```
 
-    This is generally easier to follow, but seperate commits are useful if the Pull Request contains iterations that might be interesting to see side-by-side.
+    This is generally easier to follow, but separate commits are useful if the Pull Request contains iterations that might be interesting to see side-by-side.
 
 That's it! Thank you for your contribution!
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -184,7 +184,7 @@ Accord Project source code files are made available under the [Apache License, V
 
 Accord Project documentation files are made available under the [Creative Commons Attribution 4.0 International License][creativecommons] (CC-BY-4.0).
 
-[coc]: https://github.com/accordproject/docs/blob/master/Accord%20Project%20Code%20of%20Conduct.pdf
+[coc]: https://lfprojects.org/policies/code-of-conduct/
 [stackoverflowconcerto]: http://stackoverflow.com/questions/tagged/concerto
 [apslack]: https://accord-project-slack-signup.herokuapp.com
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -132,7 +132,7 @@ The subject contains succinct description of the change:
 * no dot (.) at the end
 
 ### Footer
-The footer should contain [reference GitHub Issues that this commit addresses][github-issues].
+The footer should contain [reference GitHub Issues][github-issues] that this commit addresses.
 
 ## <a name="pullrequests"></a> GitHub Pull Request Guidelines
 Pull Requests should consist of a complete addition to the code which contains value. 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Concerto UI Library
 
-This library providers web UI components for models written in the [Concerto Modelling Language](https://github.com/accordproject/concerto).
+This library providers web UI components for models written in the [Concerto Modeling Language](https://github.com/accordproject/concerto).
 
 [![Coverage Status](https://coveralls.io/repos/github/accordproject/concerto-ui/badge.svg?branch=master)](https://coveralls.io/github/accordproject/concerto-ui?branch=master) [![GitHub license](https://img.shields.io/github/license/accordproject/concerto-ui)](https://github.com/accordproject/concerto-ui/blob/master/LICENSE) [![join slack](https://img.shields.io/badge/Accord%20Project-Join%20Slack-blue)](https://accord-project-slack-signup.herokuapp.com/) [![lerna](https://img.shields.io/badge/maintained%20with-lerna-cc00ff.svg)](https://lerna.js.org/)
 [![Build Status](https://travis-ci.org/accordproject/concerto-ui.svg?branch=master)](https://travis-ci.org/accordproject/concerto-ui)
 
-The Concerto Modelling Language is an object-oriented data description (schema) language, based on a textual domain-specific language.
+The Concerto Modeling Language is an object-oriented data description (schema) language, based on a textual domain-specific language.
 
 ## How this project is structured
 


### PR DESCRIPTION
Signed-off-by: Michael Zhou <myz227@nyu.edu>

<OVERALL SUMMARY OF PULL REQUEST>
Updated markdown files by correcting for incorrect markdown links, integrating existing links into new markdown, and ensuring consistency in markdown style. Also fixes typos, grammar, and punctuation errors in documentation. All tests confirmed to pass.

### Changes
- Modified markdown to be more appropriate with content of associated links
- Fixed typos and miscellaneous errors in punctuation and grammar

### Related Issues
- [Cicero Template Library Issue 257](https://github.com/accordproject/cicero-template-library/issues/257)
- Pull Request [#280](https://github.com/accordproject/cicero-template-library/pull/280)