### PR TITLE
feat(reactFormVisitor): Allow client to specify an array of hidden fields

### DIFF
--- a/packages/concerto-ui-react-demo/src/App.js
+++ b/packages/concerto-ui-react-demo/src/App.js
@@ -1,3 +1,4 @@
+/* eslint-disable require-jsdoc */
 /*
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -32,30 +33,46 @@ class App extends Component {
       types: [],
 
       // Source model file text
-      model: `namespace concerto
+      model: `namespace io.clause.demo.fragileGoods
 
-import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money@0.2.0.cto
-import org.accordproject.time.Duration from https://models.accordproject.org/time@0.2.0.cto
-import org.accordproject.time.Period from https://models.accordproject.org/time@0.2.0.cto
-  
-transaction MyTxn {
-  o String name optional
-}
-
-concept A {
-  o String aId
-  o String[] strings 
-  o B[] bs
-  o MonetaryAmount[] monies
-  o MonetaryAmount money
-  o Duration duration
-  o Period period
-}
-
-concept B {
-  o String string
-  o Double number
-}`,
+      import org.accordproject.cicero.contract.* from https://models.accordproject.org/cicero/contract.cto
+      import org.accordproject.cicero.runtime.* from https://models.accordproject.org/cicero/runtime.cto
+      import org.accordproject.time.Duration from https://models.accordproject.org/v2.0/time.cto
+      import org.accordproject.money.MonetaryAmount from https://models.accordproject.org/money.cto
+      
+      /**
+       * The status of a shipment
+       */
+      enum ShipmentStatus {
+        o CREATED
+        o IN_TRANSIT
+        o ARRIVED
+      }
+      
+      transaction DeliveryUpdate extends Request {
+        o DateTime startTime
+        o DateTime finishTime optional
+        o ShipmentStatus status
+        o Double[] accelerometerReadings
+      }
+      
+      transaction PayOut extends Response {
+        o MonetaryAmount amount
+      }
+      
+      /**
+       * The template model
+       */
+      asset FragileGoodsClause extends AccordContract {
+        o AccordParty buyer
+        o AccordParty seller
+        o MonetaryAmount deliveryPrice
+        o Double accelerationMin
+        o Double accelerationMax
+        o MonetaryAmount accelerationBreachPenalty
+        o Duration deliveryLimitDuration
+        o MonetaryAmount lateDeliveryPenalty
+      }`,
 
       // Rendering options
       options: {
@@ -73,7 +90,8 @@ concept B {
           'org.accordproject.cicero.contract.AccordContract.contractId',
           'org.accordproject.cicero.contract.AccordClause.clauseId',
           'org.accordproject.cicero.contract.AccordContractState.stateId',
-        ]
+          property => property.getName() === 'parties'
+        ],
       },
 
       error: null,

--- a/packages/concerto-ui-react-demo/src/App.js
+++ b/packages/concerto-ui-react-demo/src/App.js
@@ -68,7 +68,6 @@ concept B {
 
         updateExternalModels: true,
         hideIdentifiers: true,
-        hideEmptyOptionals: true
       },
 
       error: null,

--- a/packages/concerto-ui-react-demo/src/App.js
+++ b/packages/concerto-ui-react-demo/src/App.js
@@ -67,7 +67,13 @@ concept B {
         includeSampleData: 'sample', // or 'empty'
 
         updateExternalModels: true,
-        hideIdentifiers: true,
+        // hideIdentifiers: true,
+        hiddenFields: [
+          'org.accordproject.base.Transaction.transactionId',
+          'org.accordproject.cicero.contract.AccordContract.contractId',
+          'org.accordproject.cicero.contract.AccordClause.clauseId',
+          'org.accordproject.cicero.contract.AccordContractState.stateId',
+        ]
       },
 
       error: null,

--- a/packages/concerto-ui-react-demo/src/App.js
+++ b/packages/concerto-ui-react-demo/src/App.js
@@ -38,7 +38,12 @@ import org.accordproject.money.MonetaryAmount from https://models.accordproject.
 import org.accordproject.time.Duration from https://models.accordproject.org/time@0.2.0.cto
 import org.accordproject.time.Period from https://models.accordproject.org/time@0.2.0.cto
   
+transaction MyTxn {
+  o String name optional
+}
+
 concept A {
+  o String aId
   o String[] strings 
   o B[] bs
   o MonetaryAmount[] monies
@@ -62,6 +67,8 @@ concept B {
         includeSampleData: 'sample', // or 'empty'
 
         updateExternalModels: true,
+        hideIdentifiers: true,
+        hideEmptyOptionals: true
       },
 
       error: null,

--- a/packages/concerto-ui-react/dist/concertoForm.css
+++ b/packages/concerto-ui-react/dist/concertoForm.css
@@ -14,7 +14,7 @@
 
 .arrayElement, .classElement {
     border-left: 1px solid rgba(34,36,38,.15);
-    padding: 5px 5px 5px 10px
+    padding: 5px 0px 5px 10px
 }
 
 .grid {

--- a/packages/concerto-ui-react/dist/reactformvisitor.js
+++ b/packages/concerto-ui-react/dist/reactformvisitor.js
@@ -46,7 +46,17 @@ class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
    * @private
    */
   hideProperty(property, parameters) {
-    if (parameters.hiddenFields.find(fqn => fqn === property.getFullyQualifiedName())) {
+    if (parameters.hiddenFields.find(f => {
+      if (typeof f === 'function') {
+        return f(property);
+      }
+
+      if (typeof f === 'string') {
+        return f === property.getFullyQualifiedName();
+      }
+
+      return false;
+    })) {
       parameters.stack.pop();
       return true;
     }

--- a/packages/concerto-ui-react/dist/reactformvisitor.js
+++ b/packages/concerto-ui-react/dist/reactformvisitor.js
@@ -38,27 +38,17 @@ function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { de
  * @memberof module:composer-common
  */
 class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
-  constructor() {
-    super();
-    this.hiddenFields = [];
-  }
-
+  /**
+   * Helper function to determine whether to hide a property from the rendering
+   * @param {Property} property - the object being visited, either a field or a resource
+   * @param {Object} parameters  - the parameter
+   * @return {boolean} - true if the property should be hidden, false otherwise
+   * @private
+   */
   hideProperty(property, parameters) {
-    const key = _jsonpath.default.stringify(parameters.stack);
-
-    const value = _jsonpath.default.value(parameters.json, key);
-
-    const normalizedKey = key.substring(2);
-
-    if (parameters.hideEmptyOptionals && property.isOptional() && (value === null || value === '')) {
-      parameters.stack.pop();
-      return true;
-    }
-
-    if (this.hiddenFields.find(({
-      className,
-      fieldKey
-    }) => fieldKey === normalizedKey && className === property.getParent().getFullyQualifiedName())) {
+    if (parameters.hiddenFields.find(({
+      fieldFqn
+    }) => fieldFqn === property.getFullyQualifiedName())) {
       parameters.stack.pop();
       return true;
     }
@@ -78,18 +68,16 @@ class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
     let component = null;
 
     if (parameters.hideIdentifiers) {
-      let identifierClassDecl = null;
-
-      if (classDeclaration.idField) {
-        identifierClassDecl = classDeclaration;
-      } else if (classDeclaration.getSuperType()) {
-        identifierClassDecl = parameters.modelManager.getType(classDeclaration.getSuperType());
+      if (!parameters.hiddenFields) {
+        parameters.hiddenFields = [];
       }
 
-      if (identifierClassDecl) {
-        this.hiddenFields.push({
-          className: identifierClassDecl.getFullyQualifiedName(),
-          fieldKey: classDeclaration.getIdentifierFieldName()
+      const idFieldName = classDeclaration.getIdentifierFieldName();
+
+      if (idFieldName) {
+        const idField = classDeclaration.getProperty(idFieldName);
+        parameters.hiddenFields.push({
+          fieldFqn: idField.getFullyQualifiedName()
         });
       }
     }

--- a/packages/concerto-ui-react/dist/reactformvisitor.js
+++ b/packages/concerto-ui-react/dist/reactformvisitor.js
@@ -159,6 +159,12 @@ class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
     let value = _jsonpath.default.value(parameters.json, key);
 
     let component = null;
+
+    if (parameters.hiddenFields && parameters.hiddenFields.includes(key)) {
+      parameters.stack.pop();
+      return null;
+    }
+
     const styles = parameters.customClasses;
     let style = styles.field;
 
@@ -364,6 +370,11 @@ class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
     const key = _jsonpath.default.stringify(parameters.stack);
 
     let value = _jsonpath.default.value(parameters.json, key);
+
+    if (parameters.hiddenFields && parameters.hiddenFields.includes(key)) {
+      parameters.stack.pop();
+      return null;
+    }
 
     let component;
 

--- a/packages/concerto-ui-react/dist/reactformvisitor.js
+++ b/packages/concerto-ui-react/dist/reactformvisitor.js
@@ -46,9 +46,7 @@ class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
    * @private
    */
   hideProperty(property, parameters) {
-    if (parameters.hiddenFields.find(({
-      fieldFqn
-    }) => fieldFqn === property.getFullyQualifiedName())) {
+    if (parameters.hiddenFields.find(fqn => fqn === property.getFullyQualifiedName())) {
       parameters.stack.pop();
       return true;
     }
@@ -76,9 +74,7 @@ class ReactFormVisitor extends _concertoUiCore.HTMLFormVisitor {
 
       if (idFieldName) {
         const idField = classDeclaration.getProperty(idFieldName);
-        parameters.hiddenFields.push({
-          fieldFqn: idField.getFullyQualifiedName()
-        });
+        parameters.hiddenFields.push(idField.getFullyQualifiedName());
       }
     }
 

--- a/packages/concerto-ui-react/src/concertoForm.css
+++ b/packages/concerto-ui-react/src/concertoForm.css
@@ -14,7 +14,7 @@
 
 .arrayElement, .classElement {
     border-left: 1px solid rgba(34,36,38,.15);
-    padding: 5px 5px 5px 10px
+    padding: 5px 0px 5px 10px
 }
 
 .grid {

--- a/packages/concerto-ui-react/src/reactformvisitor.js
+++ b/packages/concerto-ui-react/src/reactformvisitor.js
@@ -28,29 +28,16 @@ import { Utilities, HTMLFormVisitor } from '@accordproject/concerto-ui-core';
  */
 class ReactFormVisitor extends HTMLFormVisitor {
 
-  constructor(){
-    super();
-    this.hiddenFields = [];
-  }
-
+    /**
+     * Helper function to determine whether to hide a property from the rendering
+     * @param {Property} property - the object being visited, either a field or a resource
+     * @param {Object} parameters  - the parameter
+     * @return {boolean} - true if the property should be hidden, false otherwise
+     * @private
+     */
   hideProperty(property, parameters){
-    const key = jsonpath.stringify(parameters.stack);
-    const value = jsonpath.value(parameters.json,key);
-    const normalizedKey = key.substring(2);
-
-    if (
-      parameters.hideEmptyOptionals 
-      && property.isOptional()
-      && (value === null || value === '')
-    ) {
-      parameters.stack.pop();
-      return true;
-    }
-
-    if (this.hiddenFields.find(
-        ({ className, fieldKey}) => 
-          fieldKey === normalizedKey 
-            && className === property.getParent().getFullyQualifiedName()
+    if (parameters.hiddenFields.find(
+        ({ fieldFqn }) => fieldFqn === property.getFullyQualifiedName()
       )) {
       parameters.stack.pop();
       return true;
@@ -69,16 +56,15 @@ class ReactFormVisitor extends HTMLFormVisitor {
     let component = null;
 
     if(parameters.hideIdentifiers){
-      let identifierClassDecl = null;
-      if (classDeclaration.idField) {
-        identifierClassDecl = classDeclaration;
-      } else if (classDeclaration.getSuperType()) { 
-        identifierClassDecl = parameters.modelManager.getType(classDeclaration.getSuperType());
+      if (!parameters.hiddenFields){
+        parameters.hiddenFields = [];
       }
-      if (identifierClassDecl){
-        this.hiddenFields.push({ 
-          className: identifierClassDecl.getFullyQualifiedName(),
-          fieldKey: classDeclaration.getIdentifierFieldName()
+
+      const idFieldName = classDeclaration.getIdentifierFieldName()
+      if (idFieldName){
+        const idField = classDeclaration.getProperty(idFieldName)
+        parameters.hiddenFields.push({ 
+          fieldFqn: idField.getFullyQualifiedName()
         });
       }
     }

--- a/packages/concerto-ui-react/src/reactformvisitor.js
+++ b/packages/concerto-ui-react/src/reactformvisitor.js
@@ -37,7 +37,7 @@ class ReactFormVisitor extends HTMLFormVisitor {
      */
   hideProperty(property, parameters){
     if (parameters.hiddenFields.find(
-        ({ fieldFqn }) => fieldFqn === property.getFullyQualifiedName()
+        fqn => fqn === property.getFullyQualifiedName()
       )) {
       parameters.stack.pop();
       return true;
@@ -63,9 +63,7 @@ class ReactFormVisitor extends HTMLFormVisitor {
       const idFieldName = classDeclaration.getIdentifierFieldName()
       if (idFieldName){
         const idField = classDeclaration.getProperty(idFieldName)
-        parameters.hiddenFields.push({ 
-          fieldFqn: idField.getFullyQualifiedName()
-        });
+        parameters.hiddenFields.push(idField.getFullyQualifiedName());
       }
     }
 

--- a/packages/concerto-ui-react/src/reactformvisitor.js
+++ b/packages/concerto-ui-react/src/reactformvisitor.js
@@ -37,7 +37,15 @@ class ReactFormVisitor extends HTMLFormVisitor {
      */
   hideProperty(property, parameters){
     if (parameters.hiddenFields.find(
-        fqn => fqn === property.getFullyQualifiedName()
+        f => {
+          if (typeof f === 'function'){
+            return f(property);
+          }
+          if (typeof f === 'string'){
+            return f === property.getFullyQualifiedName()
+          }
+          return false;
+        }
       )) {
       parameters.stack.pop();
       return true;

--- a/packages/concerto-ui-react/src/reactformvisitor.js
+++ b/packages/concerto-ui-react/src/reactformvisitor.js
@@ -154,6 +154,11 @@ class ReactFormVisitor extends HTMLFormVisitor {
     let value = jsonpath.value(parameters.json,key);
     let component = null;
 
+    if (parameters.hiddenFields && parameters.hiddenFields.includes(key)) {
+      parameters.stack.pop();
+      return null;
+    }
+
     const styles = parameters.customClasses;
     let style = styles.field;
     if(!field.isOptional()){
@@ -326,6 +331,11 @@ class ReactFormVisitor extends HTMLFormVisitor {
 
     const key = jsonpath.stringify(parameters.stack);
     let value = jsonpath.value(parameters.json,key);
+
+    if (parameters.hiddenFields && parameters.hiddenFields.includes(key)) {
+      parameters.stack.pop();
+      return null;
+    }
 
     let component;
     if(typeof value === 'object'){


### PR DESCRIPTION
### Changes
- By adding a `hiddenFields` property to the `options` object, the `ReactFormVisitor` will skip rendering for fields and resources that have matching keys.
- `hiddenFields` is an array of `$.` prefixed fully qualified paths, i.e. `["$.accelerationBreachPenalty", "$.contractId"]`
