### PR TITLE
fix(react): MonetaryAmount currency dropdown width on Safari

### DIFF
--- a/packages/concerto-ui-react/src/concertoForm.css
+++ b/packages/concerto-ui-react/src/concertoForm.css
@@ -29,7 +29,7 @@
 
 .monetaryAmount {
     display: grid;
-    grid-template-columns: auto 60px;
+    grid-template-columns: auto 80px;
     grid-column-gap: 5px;
 }
 


### PR DESCRIPTION
# Issue #23 
Fixes #23 by increasing cell width to 80px

![image](https://user-images.githubusercontent.com/7544022/75164112-2f24e480-5718-11ea-92ea-137a29673357.png)
