### PR TITLE
logo added to concerto-ui

### DIFF
--- a/packages/concerto-ui-react-demo/public/index.html
+++ b/packages/concerto-ui-react-demo/public/index.html
@@ -9,7 +9,8 @@
       homescreen on Android. See https://developers.google.com/web/fundamentals/engage-and-retain/web-app-manifest/
     -->
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json">
-    <link rel="shortcut icon" href="https://accordproject.github.io/concerto/latest/favicon.ico">
+    
+    <link rel="shortcut icon" href="https://avatars0.githubusercontent.com/u/29445438">
     <!--
       Notice the use of %PUBLIC_URL% in the tags above.
       It will be replaced with the URL of the `public` folder during the build.

--- a/packages/concerto-ui-react-demo/src/index.html
+++ b/packages/concerto-ui-react-demo/src/index.html
@@ -17,6 +17,7 @@ limitations under the License.
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
   <meta http-equiv="X-UA-Compatible" content="ie=edge">
+  <link rel="icon" href="https://avatars0.githubusercontent.com/u/29445438" >
   <title>Accord Project, Concerto UI Demo</title>
 </head>
 <body>


### PR DESCRIPTION
Signed-off-by: kanav <kanavraina98@gmail.com>

# Issue #48
Logo added to concerto-ui and updated the link

The logo link used is from this https://github.com/accordproject

Concerto-UI with logo
![concerto_with_logo](https://user-images.githubusercontent.com/29794748/77743884-c5616880-703e-11ea-9c41-08c48c592003.png)


Concerto-UI without logo
![concerto_without_logo](https://user-images.githubusercontent.com/29794748/77743877-bed2f100-703e-11ea-915f-46be70d03a0d.png)

Reference : https://github.com/accordproject/concerto-ui/pull/50