### PR TITLE
fix(concertoForm): Bug when adding element to nested array - Fixes #56

### DIFF
--- a/packages/concerto-ui-react/src/concertoForm.js
+++ b/packages/concerto-ui-react/src/concertoForm.js
@@ -146,7 +146,7 @@ class ConcertoForm extends Component {
 
   addElement(e, key, value){
     const array = get(this.state.value, key);
-    set(this.state.value,`${key}.${array.length}`, value);
+    set(this.state.value, [...key, array.length], value);
     this.props.onValueChange(this.state.value);
   }
 


### PR DESCRIPTION
Bug in use of lodash.set, where the path to the element was an array and a string index was appended to the string representation of the array rather than by adding a new element to the array.